### PR TITLE
BUG: abspath apparently prepends the drive letter of the current working directory on Windows

### DIFF
--- a/dtoolcore/utils.py
+++ b/dtoolcore/utils.py
@@ -78,18 +78,15 @@ def generous_parse_uri(uri):
     IS_WINDOWS_DRIVE_LETTER = len(parse_result.scheme) == 1
 
     if parse_result.scheme == '' or IS_WINDOWS_DRIVE_LETTER:
-        # ATTENTION: abspath apparently prepends the drive letter of the current working directory on Windows
-        if IS_WINDOWS_DRIVE_LETTER:
-            abspath = parse_result.scheme.upper() + ':' + parse_result.path
-        else:
-            abspath = os.path.abspath(parse_result.path)
-
+        abspath = os.path.abspath(parse_result.path)
         fixed_uri = "file://{}{}".format(
             socket.gethostname(),
             abspath
         )
         if IS_WINDOWS:
             abspath = windows_to_unix_path(abspath)
+            if IS_WINDOWS_DRIVE_LETTER:
+                abspath= parse_result.scheme.upper() + abspath[1:]
             fixed_uri = "file:///{}".format(abspath)
         parse_result = urlparse(fixed_uri)
 

--- a/dtoolcore/utils.py
+++ b/dtoolcore/utils.py
@@ -78,7 +78,12 @@ def generous_parse_uri(uri):
     IS_WINDOWS_DRIVE_LETTER = len(parse_result.scheme) == 1
 
     if parse_result.scheme == '' or IS_WINDOWS_DRIVE_LETTER:
-        abspath = os.path.abspath(parse_result.path)
+        # ATTENTION: abspath apparently prepends the drive letter of the current working directory on Windows
+        if IS_WINDOWS_DRIVE_LETTER:
+            abspath = parse_result.scheme.upper() + ':' + parse_result.path
+        else:
+            abspath = os.path.abspath(parse_result.path)
+
         fixed_uri = "file://{}{}".format(
             socket.gethostname(),
             abspath


### PR DESCRIPTION
I have encountered some unexpected behavior when testing our GUI on Windows, see https://github.com/livMatS/dtool-lookup-gui/blob/master/dtool_lookup_gui/utils/patch.py.

On Windows, urlparse will remove the drive letter and abspath will prepend the drive letter of the current working directory. See for example within a mingw64/msys2 environment:

```console
$ cygpath -wa .
C:\msys64\home\
$ python -c 'import os; from urllib.parse import urlparse; parse_result = urlparse("D:/test/path"); print(os.path.abspath(parse_result.path))'
C:/test/path
```

or just directly Python 3.10 on Windows,

```console
Python 3.10.2 (tags/v3.10.2:a58ebcc, Jan 17 2022, 14:12:15) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.getcwd()
'C:\\Users\\admin\\AppData\\Local\\Programs\\Python\\Python310'
>>> from urllib.parse import urlparse; parse_result = urlparse("D:/test/path"); print(os.path.abspath(parse_result.path))
C:\test\path
```

Best