### PR TITLE
pkg_resources deprecated with Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Git checkout

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 Changed
 ^^^^^^^
 
+- ``pkg_resources`` has been deprecated with Python 3.12. Replaced use of ``pkg_resources.iter_entry_points`` with ``importlib.metadata.entry_points``.
 
 Deprecated
 ^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,12 @@ This change log uses principles from `keep a changelog <http://keepachangelog.co
 Added
 ^^^^^
 
+- Test with Python 3.13 in CI workflow
 
 Changed
 ^^^^^^^
 
-- ``pkg_resources`` has been deprecated with Python 3.12. Replaced use of ``pkg_resources.iter_entry_points`` with ``importlib.metadata.entry_points``.
+- ``pkg_resources`` has been deprecated with Python 3.12. Replaced use of ``pkg_resources.iter_entry_points`` with ``importlib.metadata.entry_points`` for >= Python 3.8
 
 Deprecated
 ^^^^^^^^^^

--- a/dtoolcore/__init__.py
+++ b/dtoolcore/__init__.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 import uuid
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 from collections import defaultdict
 
 import dtoolcore.utils
@@ -59,7 +59,10 @@ def _generate_storage_broker_lookup():
     """Return dictionary of available storage brokers."""
     logger.debug("In _generate_storage_broker_lookup...")
     storage_broker_lookup = dict()
-    for entrypoint in iter_entry_points("dtool.storage_brokers"):
+
+    eps = entry_points()
+
+    for entrypoint in eps.select(group="dtool.storage_brokers"):
         StorageBroker = entrypoint.load()
         key = StorageBroker.key
         logger.debug("_gnerate_stroage_broker_lookup.key: {}".format(key))

--- a/dtoolcore/__init__.py
+++ b/dtoolcore/__init__.py
@@ -3,6 +3,7 @@
 """
 
 import os
+import sys
 
 import datetime
 import logging
@@ -11,7 +12,6 @@ import shutil
 import tempfile
 import uuid
 
-from importlib.metadata import entry_points
 from collections import defaultdict
 
 import dtoolcore.utils
@@ -60,9 +60,18 @@ def _generate_storage_broker_lookup():
     logger.debug("In _generate_storage_broker_lookup...")
     storage_broker_lookup = dict()
 
-    eps = entry_points()
+    if sys.version_info >= (3, 8):
+        from importlib.metadata import entry_points
+        eps = entry_points()
+        if sys.version_info >= (3, 10):
+            entrypoints = eps.select(group="dtool.storage_brokers")
+        else:
+            entrypoints = eps.get("dtool.storage_brokers", [])
+    else:
+        from pkg_resources import iter_entry_points
+        entrypoints = iter_entry_points("dtool.storage_brokers")
 
-    for entrypoint in eps.select(group="dtool.storage_brokers"):
+    for entrypoint in entrypoints:
         StorageBroker = entrypoint.load()
         key = StorageBroker.key
         logger.debug("_gnerate_stroage_broker_lookup.key: {}".format(key))


### PR DESCRIPTION
The use of pkg_resources has been deprecated with Python 12, see https://github.com/jic-dtool/dtoolcore/issues/29

This PR uses `importlib.metadata.entry_points` instead, see https://www.perplexity.ai/search/is-pkg-resources-deprecated-wi-P461N47NSXuy4HoaxbML2A#0.

This will, however, likely break for Python < 3.10-
